### PR TITLE
feat: improve tracked information

### DIFF
--- a/functions/events/search.ts
+++ b/functions/events/search.ts
@@ -11,10 +11,11 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
         await context.request.json(),
     ]);
 
-    const resp = await client.query('INSERT INTO search_events (timestamp, version, origin, term) VALUES (current_timestamp, $1, $2, $3);', [
+    const resp = await client.query('INSERT INTO search_events (timestamp, version, origin, term, context) VALUES (current_timestamp, $1, $2, $3, $4);', [
         searchEvent.version,
         searchEvent.origin,
-        searchEvent.term
+        searchEvent.term,
+        JSON.stringify(searchEvent.context),
     ]);
     if (resp.rowCount !== 1) {
         console.log('Error writing search event', searchEvent);

--- a/public/index.js
+++ b/public/index.js
@@ -19,7 +19,7 @@ window.toSearch = function (word) {
     input.value = word;
 }
 
-window.runSearch = function (word, origin) {
+window.runSearch = function (word, origin, context) {
     const search = word.replace(/[^a-z0-9]/gi, '');
     const found = loadedKeys.filter((k) => k.includes(search));
     found.sort((a,b) => {
@@ -43,7 +43,7 @@ window.runSearch = function (word, origin) {
         el.setAttribute('href', '#');
         el.setAttribute('onclick', 'toSearch(this.innerHTML);runSearch(this.innerHTML, "onClick");return false;');
     }
-    navigator.sendBeacon('events/search', JSON.stringify({ term: `${word}`, origin: `${origin}`, version: 1 }));
+    navigator.sendBeacon('events/search', JSON.stringify({ term: `${word}`, origin: `${origin}`, context: { found: found.length, ...context }, version: 2 }));
 }
 
 const data = fetch('./result.json')
@@ -57,7 +57,7 @@ const data = fetch('./result.json')
                 tbody.innerHTML = '<tr><td>...</td><td>...</td><td>...</td></tr>';
                 return;
             }
-            runSearch(inputValue.toLowerCase(), 'onKeyup');
+            runSearch(inputValue.toLowerCase(), 'onKeyup', { key: e.key });
         };
         input.addEventListener("keyup", debounce(onKeyup, 250));
 


### PR DESCRIPTION
Talking about
- https://github.com/ildede/sinonimi/issues/11

To have a closer look on _3. Same word searched two time in less than 1 second_ we can add some information on what we are tracking.

I think that the "two searches" are triggered by people that write a word and then press _Enter_ "to confirm".
It's a common practice in lots of form, so I can understand.

In this PR we are adding the key that was released and the count of the terms found.

With the key, we can confirm this opinion and in case decide what to do.